### PR TITLE
Unittest for DeleteMapping

### DIFF
--- a/src/main/java/com/example/kinoxpbackend/controllers/TheaterRestController.java
+++ b/src/main/java/com/example/kinoxpbackend/controllers/TheaterRestController.java
@@ -71,4 +71,3 @@ public class TheaterRestController {
 }
 
 
-}

--- a/src/test/java/com/example/kinoxpbackend/controllers/DeleteMappingTest.java
+++ b/src/test/java/com/example/kinoxpbackend/controllers/DeleteMappingTest.java
@@ -1,0 +1,68 @@
+package com.example.kinoxpbackend.controllers;
+
+import com.example.kinoxpbackend.models.Movie;
+import com.example.kinoxpbackend.services.MovieService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DeleteMappingTest {
+
+    @Mock
+    private MovieService movieService;
+
+    @InjectMocks
+    private MovieRestController movieRestController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(movieRestController).build();
+    }
+
+    @Test
+    void testDeleteMovie() throws Exception {
+        // Prepare a Movie object
+        Movie movie = new Movie();
+        movie.setId(1);
+        movie.setTitle("Test Movie");
+
+        // Mock the service findMovieById method
+        when(movieService.findMovieById(1)).thenReturn(Optional.of(movie));
+
+        // Perform DELETE request to /movie/1
+        mockMvc.perform(delete("/movie/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // Verify that the service deleteMovie method was called
+        verify(movieService, times(1)).deleteMovie(movie);
+    }
+
+    @Test
+    void testDeleteMovieNotFound() throws Exception {
+        // Mock the service findMovieById method to return empty
+        when(movieService.findMovieById(1)).thenReturn(Optional.empty());
+
+        // Perform DELETE request to /movie/1
+        mockMvc.perform(delete("/movie/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+        // Verify that the service deleteMovie method was not called
+        verify(movieService, times(0)).deleteMovie(any(Movie.class));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new test class for the `MovieRestController` and makes a minor formatting change in the `TheaterRestController`. The most important changes include the addition of comprehensive test cases for the delete operation in the `MovieRestController`.

### New Test Class for `MovieRestController`:

* [`src/test/java/com/example/kinoxpbackend/controllers/DeleteMappingTest.java`](diffhunk://#diff-6a1955f6a272cc8793593cf059bb6490e3879184a0fac20e5dd61958ecb80d45R1-R68): Added a new test class `DeleteMappingTest` with test cases for the delete operation. This includes setup with Mockito, and tests for both successful deletion and handling of a non-existent movie.

### Minor Formatting Change:

* [`src/main/java/com/example/kinoxpbackend/controllers/TheaterRestController.java`](diffhunk://#diff-51625a7481af21d28b0597d0dfd0b83555a5b6c58dc0812ca0b9bc199f605419L74): Removed an extra closing brace to clean up the code formatting.